### PR TITLE
fix RT #105643, missing quotes for { in regex

### DIFF
--- a/lib/Parse/Eyapp/Parse.yp
+++ b/lib/Parse/Eyapp/Parse.yp
@@ -1320,13 +1320,13 @@ sub _Lexer {
         return($1, [ $1, $lineno[0] ]);
     };
 
-        $$input=~/\G\s*{/gc and return ('CODE', &slurp_perl_code());  # }
+        $$input=~/\G\s*\{/gc and return ('CODE', &slurp_perl_code());  # }
 
     if($lexlevel == 0) {# In head section
 
         $$input=~/\G%(left|right|nonassoc)/gc and return('ASSOC',[ uc($1), $lineno[0] ]);
 
-            $$input=~/\G%{/gc
+            $$input=~/\G%\{/gc
         and do {
             my($code);
 

--- a/lib/Parse/Eyapp/Treeregexp.yp
+++ b/lib/Parse/Eyapp/Treeregexp.yp
@@ -373,7 +373,7 @@ sub _Lexer {
 
         return('REGEXP', [$string, $tokenbegin, $options]);
     };
-        $input=~/\G%{/gc
+        $input=~/\G%\{/gc
     and do {
         my($code);
 
@@ -385,7 +385,7 @@ sub _Lexer {
         return('Parse::Eyapp::Treeregexp::GLOBALCODE', [$code, $tokenbegin]);
     };
 
-        $input=~/\G{/gc
+        $input=~/\G\{/gc
     and do {
         my($level,$from,$code);
 


### PR DESCRIPTION
https://rt.cpan.org/Ticket/Display.html?id=105643
