### PR TITLE
add encoding info to POD

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -25,6 +25,11 @@ WriteMakefile(
     'EXE_FILES'    => \@exe_files,
 #    ABSTRACT_FROM  => 'lib/Parse/Eyapp.pod', 
     AUTHOR         => 'Will Braswell <wbraswell_cpan@NOSPAM.nym.hush.com> (Remove "NOSPAM".)',
+	'META_MERGE'    => {
+        'resources' => {
+            'repository' => 'https://github.com/wbraswell/parse-yapp',
+        },
+    },
 );
 
 sub MY::postamble {

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -225,6 +225,7 @@ EOSQT
 
 __END__
 
+=encoding utf8
 =head1 NAME 
 
 Makefile.PL - Makefile generator for Parse::Eyapp. Developer notes


### PR DESCRIPTION
because the copyright symbol is used